### PR TITLE
Bug fix - Fixed error "Tablename start with invalid character error"

### DIFF
--- a/Dexiom.EPPlusExporter/Helpers/WorksheetHelper.cs
+++ b/Dexiom.EPPlusExporter/Helpers/WorksheetHelper.cs
@@ -5,21 +5,43 @@ using System.Reflection;
 using Dexiom.EPPlusExporter.Extensions;
 using OfficeOpenXml;
 using OfficeOpenXml.Table;
+using System;
 
 namespace Dexiom.EPPlusExporter.Helpers
 {
     public static class WorksheetHelper
     {
+        private const string ESCAPE_PREFIX = "__$";
+        private const string SPACE_PLACEHOLDER = "__!";
         #region Internal
         internal static void FormatAsTable(ExcelRangeBase range, TableStyles tableStyle, string tableName, bool autoFitColumns = true)
         {
+            string escapedTableName = FormatTableName(tableName);
+
             //format the table
-            var table = range.Worksheet.Tables.Add(range, tableName);
+            var table = range.Worksheet.Tables.Add(range, escapedTableName);
             table.TableStyle = tableStyle;
 
             if (autoFitColumns)
                 range.AutoFitColumns();
         }
         #endregion
+
+        private static string FormatTableName(string tableName)
+        {
+            string escapedTableName = tableName;
+
+            char firstChar = tableName[0];
+
+            if(Char.IsLetter(firstChar) == false)
+            {
+                escapedTableName =  $"{ESCAPE_PREFIX}{escapedTableName}";
+            }
+
+            escapedTableName = escapedTableName.Replace(" ", SPACE_PLACEHOLDER);
+
+            return escapedTableName;
+        }
+
     }
 }

--- a/Dexiom.EPPlusExporterTests/EnumerableExporterTests.cs
+++ b/Dexiom.EPPlusExporterTests/EnumerableExporterTests.cs
@@ -168,9 +168,11 @@ namespace Dexiom.EPPlusExporter.Tests
                 .DefaultNumberFormat(typeof(int), "00")
                 .CreateExcelPackage()
                 .Workbook.Worksheets.First();
+
+            string numberDecimalSeparator = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
             
             Assert.IsTrue(excelWorksheet.Cells[2, 2].Text == DateTime.Today.ToString("DATE: yyyy-MM-dd")); //DateValue
-            Assert.IsTrue(excelWorksheet.Cells[2, 3].Text == "10.20 $"); //DoubleValue
+            Assert.IsTrue(excelWorksheet.Cells[2, 3].Text == $"10{numberDecimalSeparator}20 $"); //DoubleValue
             Assert.IsTrue(excelWorksheet.Cells[2, 4].Text == "05"); //IntValue
         }
 
@@ -189,8 +191,10 @@ namespace Dexiom.EPPlusExporter.Tests
                 .CreateExcelPackage()
                 .Workbook.Worksheets.First();
 
+            string numberDecimalSeparator = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
+
             Assert.IsTrue(excelWorksheet.Cells[2, 2].Text == DateTime.Today.ToString("DATE: yyyy-MM-dd")); //DateValue
-            Assert.IsTrue(excelWorksheet.Cells[2, 3].Text == "10.20 $"); //DoubleValue
+            Assert.IsTrue(excelWorksheet.Cells[2, 3].Text == $"10{numberDecimalSeparator}20 $"); //DoubleValue
             Assert.IsTrue(excelWorksheet.Cells[2, 4].Text == "05"); //IntValue
         }
 

--- a/Dexiom.EPPlusExporterTests/ObjectExporterTests.cs
+++ b/Dexiom.EPPlusExporterTests/ObjectExporterTests.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Dexiom.EPPlusExporterTests.Helpers;
 using OfficeOpenXml.Style;
+using System.Globalization;
 
 namespace Dexiom.EPPlusExporter.Tests
 {
@@ -117,8 +118,10 @@ namespace Dexiom.EPPlusExporter.Tests
                 .CreateExcelPackage()
                 .Workbook.Worksheets.First();
 
+            string numberDecimalSeparator = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
+
             Assert.IsTrue(excelWorksheet.Cells[3, 2].Text == DateTime.Today.ToString("DATE: yyyy-MM-dd")); //DateValue
-            Assert.IsTrue(excelWorksheet.Cells[4, 2].Text == "10.20 $"); //DoubleValue
+            Assert.IsTrue(excelWorksheet.Cells[4, 2].Text == $"10{numberDecimalSeparator}20 $"); //DoubleValue
             Assert.IsTrue(excelWorksheet.Cells[5, 2].Text == "05"); //IntValue
         }
 
@@ -134,8 +137,10 @@ namespace Dexiom.EPPlusExporter.Tests
                 .CreateExcelPackage()
                 .Workbook.Worksheets.First();
 
+            string numberDecimalSeparator = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
+
             Assert.IsTrue(excelWorksheet.Cells[3, 2].Text == DateTime.Today.ToString("DATE: yyyy-MM-dd")); //DateValue
-            Assert.IsTrue(excelWorksheet.Cells[4, 2].Text == "10.20 $"); //DoubleValue
+            Assert.IsTrue(excelWorksheet.Cells[4, 2].Text == $"10{numberDecimalSeparator}20 $"); //DoubleValue
             Assert.IsTrue(excelWorksheet.Cells[5, 2].Text == "05"); //IntValue
         }
 


### PR DESCRIPTION
Hi

Great work first of all.

I've fixed small bug I encountered.

It's related to worksheet name which is used in calls to WorksheetHelper.FormatAsTable.
When new ExcelTable is added to ExcelTableCollection, EPPlus validates table name. If you use non letter character e.g. 1 as first character error "Tablename start with invalid character error" is thrown.

I've created rather naive fix with idea that if needed, table can be retrieved from ExcelTableCollection by worksheet name. That's why I prefix worksheet name with made up text. It's not perfect solution but it works.

Since I use different regional setting on my machine some tests didn't pass.
I use comma number decimal separator and NumberFormatForTest test didn't pass because of that.
